### PR TITLE
feat(tests): make tests with lint staged

### DIFF
--- a/src/eslint/__snapshots__/package.test.js.snap
+++ b/src/eslint/__snapshots__/package.test.js.snap
@@ -35,7 +35,10 @@ Object {
     },
   },
   "lint-staged": Object {
-    "*.{js,jsx}": "eslint",
+    "*.{js,jsx}": Array [
+      "eslint",
+      "jest --bail --findRelatedTests",
+    ],
   },
   "metapak": Object {
     "data": Object {
@@ -81,7 +84,10 @@ Object {
     },
   },
   "lint-staged": Object {
-    "*.{js,jsx}": "eslint",
+    "*.{js,jsx}": Array [
+      "eslint",
+      "jest --bail --findRelatedTests",
+    ],
   },
   "metapak": Object {
     "data": Object {

--- a/src/eslint/package.js
+++ b/src/eslint/package.js
@@ -71,7 +71,10 @@ module.exports = packageConf => {
 
   // Add lint-staged config
   packageConf['lint-staged'] = packageConf['lint-staged'] || {};
-  packageConf['lint-staged']['*.{js,jsx}'] = 'eslint';
+  packageConf['lint-staged']['*.{js,jsx}'] = [
+    'eslint',
+    'jest --bail --findRelatedTests',
+  ];
 
   // Add prettier config
   packageConf.prettier = {

--- a/src/main/__snapshots__/package.test.js.snap
+++ b/src/main/__snapshots__/package.test.js.snap
@@ -15,6 +15,7 @@ Object {
   "husky": Object {
     "hooks": Object {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-commit": "npm run checkStaged",
     },
   },
   "license": "SEE LICENSE IN LICENSE.md",
@@ -25,6 +26,7 @@ Object {
   },
   "scripts": Object {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
+    "checkStaged": "if ! git diff-files --quiet --ignore-submodules ; then echo \\"⚠️ - Unstaged files found:\\"; echo $(git diff-files --shortstat); fi;",
     "cli": "env NODE_ENV=\${NODE_ENV:-cli}",
     "lint": "echo \\"WARNING: No linter configured\\"",
     "preversion": "npm run lint && npm run metapak -- -s",

--- a/src/main/package.js
+++ b/src/main/package.js
@@ -7,6 +7,9 @@ const GITHUB_REPOSITORY_REGEXP = /git\+https:\/\/github.com\/([a-zA-Z0-9-]+)\/([
 const LINT_SCRIPT = 'npm run lint';
 const METAPAK_CHECK_SCRIPT = 'npm run metapak -- -s';
 
+const PRE_COMMIT_CWD_WARNING =
+  'if ! git diff-files --quiet --ignore-submodules ; then echo "⚠️ - Unstaged files found:"; echo $(git diff-files --shortstat); fi;';
+
 module.exports = packageConf => {
   packageConf.license = 'SEE LICENSE IN LICENSE.md';
 
@@ -55,6 +58,19 @@ module.exports = packageConf => {
   packageConf.husky.hooks['commit-msg'] = ensureScript(
     packageConf.husky.hooks['commit-msg'],
     'commitlint -E HUSKY_GIT_PARAMS',
+  );
+
+  // Add husky hooks to test if there is staged file
+  packageConf.scripts.checkStaged = ensureScript(
+    packageConf.scripts.checkStaged,
+    PRE_COMMIT_CWD_WARNING,
+  );
+
+  packageConf.husky = packageConf.husky || {};
+  packageConf.husky.hooks = packageConf.husky.hooks || {};
+  packageConf.husky.hooks['pre-commit'] = ensureScript(
+    packageConf.husky.hooks['pre-commit'],
+    'npm run checkStaged',
   );
 
   // This job is already done by NPM, but once,.

--- a/src/tests/__snapshots__/package.test.js.snap
+++ b/src/tests/__snapshots__/package.test.js.snap
@@ -5,11 +5,6 @@ Object {
   "devDependencies": Object {
     "jest": "^23.6.0",
   },
-  "husky": Object {
-    "hooks": Object {
-      "pre-commit": "npm t",
-    },
-  },
   "jest": Object {
     "coverageReporters": Array [
       "lcov",

--- a/src/tests/package.js
+++ b/src/tests/package.js
@@ -22,13 +22,6 @@ module.exports = packageConf => {
     TEST_SCRIPT,
   );
 
-  packageConf.husky = packageConf.husky || {};
-  packageConf.husky.hooks = packageConf.husky.hooks || {};
-  packageConf.husky.hooks['pre-commit'] = ensureScript(
-    packageConf.husky.hooks['pre-commit'],
-    TEST_SCRIPT,
-  );
-
   // Add the jest config
   packageConf.jest = {
     coverageReporters: ['lcov'],


### PR DESCRIPTION
While doing my presentation for ChtiJs I have discovered a really interessant feature ! 😄 
Instead of doing all tests with jest you can use lint-staged to pass files that I have been modified and jest will find related tests and just run them instead of everything.

Fix: https://github.com/sencrop/metapak-sencrop/issues/5